### PR TITLE
fix: improve mobile responsive UI and repo name display

### DIFF
--- a/src/components/svelte/Dashboard.svelte
+++ b/src/components/svelte/Dashboard.svelte
@@ -14,6 +14,7 @@
 
   let chartCanvas: HTMLCanvasElement;
   let chart: Chart<"pie"> | null = null;
+  let isMobile = $state(false);
 
   // Computed stats
   let totalStars = $derived(repos.reduce((sum, r) => sum + r.stars, 0));
@@ -48,6 +49,20 @@
   onMount(() => {
     Chart.register(PieController, ArcElement, Tooltip, Legend);
 
+    // Check initial screen size
+    const mediaQuery = window.matchMedia("(max-width: 639px)");
+    isMobile = mediaQuery.matches;
+
+    const handleResize = (e: MediaQueryListEvent | MediaQueryList) => {
+      isMobile = e.matches;
+      if (chart) {
+        chart.options.plugins!.legend!.position = isMobile ? "bottom" : "right";
+        chart.update();
+      }
+    };
+
+    mediaQuery.addEventListener("change", handleResize);
+
     const data = languageDistribution();
     if (data.length > 0 && chartCanvas) {
       chart = new Chart(chartCanvas, {
@@ -67,7 +82,7 @@
           maintainAspectRatio: false,
           plugins: {
             legend: {
-              position: "right",
+              position: isMobile ? "bottom" : "right",
               labels: {
                 usePointStyle: true,
                 padding: 12,
@@ -79,6 +94,7 @@
     }
 
     return () => {
+      mediaQuery.removeEventListener("change", handleResize);
       chart?.destroy();
     };
   });
@@ -98,7 +114,7 @@
   }
 </script>
 
-<div class="space-y-8">
+<div class="space-y-8 overflow-hidden">
   <!-- Stats Overview -->
   <div class="grid grid-cols-2 md:grid-cols-4 gap-4">
     <div class="card p-4 text-center">
@@ -127,9 +143,9 @@
     </div>
   </div>
 
-  <div class="grid md:grid-cols-2 gap-8">
+  <div class="grid md:grid-cols-2 gap-4 md:gap-8">
     <!-- Language Distribution Chart -->
-    <div class="card p-6">
+    <div class="card p-4 sm:p-6 min-w-0">
       <h3 class="text-lg font-medium mb-4 flex items-center gap-2">
         <Icon icon="ph:chart-pie-bold" class="w-5 h-5" />
         Language Distribution
@@ -140,22 +156,27 @@
     </div>
 
     <!-- Top Starred -->
-    <div class="card p-6">
+    <div class="card p-4 sm:p-6 min-w-0">
       <h3 class="text-lg font-medium mb-4 flex items-center gap-2">
         <Icon icon="ph:star-bold" class="w-5 h-5 text-yellow-500" />
         Most Starred
       </h3>
-      <div class="space-y-2">
+      <div class="space-y-2 min-w-0">
         {#each topRepos as repo, i}
+          {@const [owner, repoName] = repo.fullName.split("/")}
           <a
             href={`https://github.com/${repo.fullName}`}
             target="_blank"
             rel="noopener noreferrer"
-            class="flex items-center gap-3 p-2 rounded-lg hover:bg-zinc-100 dark:hover:bg-zinc-800 transition-colors"
+            class="flex items-center gap-2 sm:gap-3 p-2 rounded-lg hover:bg-zinc-100 dark:hover:bg-zinc-800 transition-colors min-w-0"
+            title={repo.fullName}
           >
-            <span class="text-zinc-400 w-6 text-right">{i + 1}</span>
-            <span class="flex-1 truncate text-sm">{repo.fullName}</span>
-            <span class="flex items-center gap-1 text-sm text-zinc-500">
+            <span class="text-zinc-400 w-5 sm:w-6 text-right shrink-0">{i + 1}</span>
+            <div class="flex-1 min-w-0">
+              <div class="font-medium text-sm text-primary-600 dark:text-primary-400 truncate">{repoName}</div>
+              <div class="text-xs text-zinc-400 truncate">{owner}</div>
+            </div>
+            <span class="flex items-center gap-1 text-sm text-zinc-500 shrink-0">
               <Icon icon="ph:star-fill" class="w-4 h-4 text-yellow-500" />
               {formatNumber(repo.stars)}
             </span>
@@ -166,21 +187,26 @@
   </div>
 
   <!-- Recently Starred -->
-  <div class="card p-6">
+  <div class="card p-4 sm:p-6 min-w-0">
     <h3 class="text-lg font-medium mb-4 flex items-center gap-2">
       <Icon icon="ph:clock-bold" class="w-5 h-5" />
       Recently Starred
     </h3>
-    <div class="grid md:grid-cols-2 gap-2">
+    <div class="grid md:grid-cols-2 gap-2 min-w-0">
       {#each recentlyStarred as repo}
+        {@const [owner, repoName] = repo.fullName.split("/")}
         <a
           href={`https://github.com/${repo.fullName}`}
           target="_blank"
           rel="noopener noreferrer"
-          class="flex items-center gap-3 p-2 rounded-lg hover:bg-zinc-100 dark:hover:bg-zinc-800 transition-colors"
+          class="flex items-center gap-2 sm:gap-3 p-2 rounded-lg hover:bg-zinc-100 dark:hover:bg-zinc-800 transition-colors min-w-0"
+          title={repo.fullName}
         >
-          <span class="flex-1 truncate text-sm">{repo.fullName}</span>
-          <span class="text-xs text-zinc-500">
+          <div class="flex-1 min-w-0">
+            <div class="font-medium text-sm text-primary-600 dark:text-primary-400 truncate">{repoName}</div>
+            <div class="text-xs text-zinc-400 truncate">{owner}</div>
+          </div>
+          <span class="text-xs text-zinc-500 shrink-0 whitespace-nowrap">
             {formatDate(repo.starredAt)}
           </span>
         </a>

--- a/src/components/svelte/Header.svelte
+++ b/src/components/svelte/Header.svelte
@@ -16,8 +16,9 @@
       <div class="flex items-center gap-4">
         <a href="/pocket/" class="flex items-center gap-2 hover:opacity-80 transition-opacity group">
           <img src="/pocket/favicon.png" alt="Pocket" class="w-8 h-8 rounded-full transition-transform group-hover:scale-110" />
-          <h1 class="text-2xl font-display font-bold text-primary-600 dark:text-primary-400 dark:drop-shadow-[0_0_10px_rgba(6,182,212,0.3)] tracking-wide">
-            ViPro's Picks
+          <h1 class="text-lg sm:text-2xl font-display font-bold text-primary-600 dark:text-primary-400 dark:drop-shadow-[0_0_10px_rgba(6,182,212,0.3)] tracking-wide whitespace-nowrap">
+            <span class="sm:hidden">Pocket</span>
+            <span class="hidden sm:inline">ViPro's Picks</span>
           </h1>
         </a>
       </div>

--- a/src/components/svelte/RepoCard.svelte
+++ b/src/components/svelte/RepoCard.svelte
@@ -13,6 +13,9 @@
 
   let isExpanded = $state(false);
 
+  // Split fullName into owner and repo name
+  let [owner, repoName] = $derived(repo.fullName.split("/"));
+
   function formatNumber(num: number): string {
     if (num >= 1000000) {
       return (num / 1000000).toFixed(1) + "M";
@@ -56,10 +59,13 @@
     {:else}
       <span class="w-3 h-3 flex-shrink-0"></span>
     {/if}
-    <span class="font-medium text-primary-600 dark:text-primary-400 group-hover:underline">
-      {repo.fullName}
-    </span>
-    <span class="text-zinc-500 text-sm truncate flex-1">
+    <div class="flex flex-col min-w-0 flex-shrink-0">
+      <span class="font-medium text-primary-600 dark:text-primary-400 group-hover:underline">
+        {repoName}
+      </span>
+      <span class="text-xs text-zinc-400">{owner}</span>
+    </div>
+    <span class="text-zinc-500 text-sm truncate flex-1 min-w-0">
       {parseEmoji(repo.description)}
     </span>
     <span class="flex items-center gap-1 text-sm text-zinc-500 flex-shrink-0">
@@ -75,17 +81,18 @@
   <div data-repo-card class="card p-4 hover:border-primary-300 dark:hover:border-primary-500/30 transition-all duration-300 dark:hover:shadow-[0_0_20px_rgba(6,182,212,0.15)]">
     <div class="flex items-start gap-4">
       <div class="flex-1 min-w-0">
-        <div class="flex items-center gap-2 mb-1">
+        <div class="mb-1">
           <a
             href={`https://github.com/${repo.fullName}`}
             target="_blank"
             rel="noopener noreferrer"
-            class="font-medium text-primary-600 dark:text-primary-400 hover:underline"
+            class="hover:underline"
           >
-            {repo.fullName}
+            <span class="font-medium text-primary-600 dark:text-primary-400">{repoName}</span>
+            <span class="text-xs text-zinc-400 ml-1">{owner}</span>
           </a>
           {#if repo.language}
-            <span class="flex items-center gap-1 text-xs text-zinc-500">
+            <span class="flex items-center gap-1 text-xs text-zinc-500 inline-flex ml-2">
               <span
                 class="w-2 h-2 rounded-full"
                 style="background-color: {getLanguageColor(repo.language)}"
@@ -121,9 +128,10 @@
         href={`https://github.com/${repo.fullName}`}
         target="_blank"
         rel="noopener noreferrer"
-        class="font-medium text-primary-600 dark:text-primary-400 hover:underline line-clamp-1"
+        class="hover:underline min-w-0"
       >
-        {repo.fullName}
+        <div class="font-medium text-primary-600 dark:text-primary-400 truncate">{repoName}</div>
+        <div class="text-xs text-zinc-400">{owner}</div>
       </a>
       <button
         onclick={() => (isExpanded = !isExpanded)}

--- a/src/components/svelte/SearchFilter.svelte
+++ b/src/components/svelte/SearchFilter.svelte
@@ -84,7 +84,7 @@
 <div class="space-y-4 mb-8">
   <!-- Search bar -->
   <div class="flex gap-4 flex-wrap">
-    <div class="relative flex-1 min-w-64">
+    <div class="relative flex-1 min-w-0 sm:min-w-64">
       <Icon
         icon="ph:magnifying-glass-bold"
         class="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-zinc-400"
@@ -133,12 +133,12 @@
       </button>
 
       {#if showLanguages}
-        <div class="absolute left-0 mt-2 w-64 max-h-80 overflow-y-auto bg-white dark:bg-zinc-900 rounded-lg shadow-lg border border-zinc-200 dark:border-zinc-700 p-2 z-50">
+        <div class="absolute left-0 mt-2 w-64 max-w-[calc(100vw-2rem)] max-h-80 overflow-y-auto bg-white dark:bg-zinc-900 rounded-lg shadow-lg border border-zinc-200 dark:border-zinc-700 p-2 z-50">
           <div class="grid grid-cols-2 gap-1">
             {#each languages as lang}
               <button
                 onclick={() => toggleLanguage(lang)}
-                class="tag {filter.languages.includes(lang) ? 'tag-active' : ''}"
+                class="tag {filter.languages.includes(lang) ? 'tag-active' : ''} truncate"
               >
                 {lang}
               </button>
@@ -169,7 +169,7 @@
       </button>
 
       {#if showTopics}
-        <div class="absolute left-0 mt-2 w-80 max-h-80 overflow-y-auto bg-white dark:bg-zinc-900 rounded-lg shadow-lg border border-zinc-200 dark:border-zinc-700 p-2 z-50">
+        <div class="absolute left-0 sm:left-auto sm:right-0 mt-2 w-[calc(100vw-2rem)] sm:w-80 max-h-80 overflow-y-auto bg-white dark:bg-zinc-900 rounded-lg shadow-lg border border-zinc-200 dark:border-zinc-700 p-2 z-50">
           <div class="flex flex-wrap gap-1">
             {#each topics.slice(0, 50) as topic}
               <button


### PR DESCRIPTION
## Summary
- Header: show shortened "Pocket" title on mobile (< 640px), full "ViPro's Picks" on desktop
- SearchFilter: fix dropdown menu overflow on narrow screens with `max-w-[calc(100vw-2rem)]`
- Dashboard: responsive chart legend position (bottom on mobile, right on desktop)
- Dashboard: fix horizontal overflow with `min-w-0` and `overflow-hidden`
- RepoCard & Dashboard: display repo name prominently with author below for better readability

## Test plan
- [ ] Test on mobile viewport (375px width)
- [ ] Verify header shows "Pocket" on mobile, "ViPro's Picks" on desktop
- [ ] Verify Topics dropdown doesn't overflow screen
- [ ] Verify Dashboard chart legend is at bottom on mobile
- [ ] Verify no horizontal scrollbar on mobile
- [ ] Verify repo names are fully visible (not truncated with "...")
- [ ] Test on desktop viewport to ensure no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)