### PR TITLE
feat: change hot indicator to show top 3 repos

### DIFF
--- a/src/components/svelte/App.svelte
+++ b/src/components/svelte/App.svelte
@@ -8,14 +8,15 @@
   import KeyboardShortcuts from "./KeyboardShortcuts.svelte";
   import type { FilterState, LayoutMode, SortField, SortOrder } from "../../lib/types";
   
-  import { 
-    repos, 
-    filteredRepos, 
-    languages, 
-    topics, 
-    isLoading, 
-    filter as filterStore, 
-    loadData 
+  import {
+    repos,
+    filteredRepos,
+    languages,
+    topics,
+    isLoading,
+    filter as filterStore,
+    loadData,
+    top3FullNames
   } from "../../stores/repos";
 
   // State using Svelte 5 runes, but sourced from stores
@@ -107,7 +108,7 @@
           <div class="animate-spin rounded-full h-12 w-12 border-b-2 border-primary-500"></div>
         </div>
       {:else}
-        <RepoList repos={$filteredRepos} {layoutMode} />
+        <RepoList repos={$filteredRepos} {layoutMode} top3FullNames={$top3FullNames} />
       {/if}
     {/if}
   </main>

--- a/src/components/svelte/RepoCard.svelte
+++ b/src/components/svelte/RepoCard.svelte
@@ -7,9 +7,10 @@
   interface Props {
     repo: Repo;
     layoutMode: LayoutMode;
+    isHot?: boolean;
   }
 
-  let { repo, layoutMode }: Props = $props();
+  let { repo, layoutMode, isHot = false }: Props = $props();
 
   let isExpanded = $state(false);
 
@@ -35,10 +36,6 @@
     });
   }
 
-  function isHot(pushedAt: string): boolean {
-    const daysSincePush = (Date.now() - new Date(pushedAt).getTime()) / (1000 * 60 * 60 * 24);
-    return daysSincePush <= 30; // Active if updated in the last 30 days
-  }
 </script>
 
 {#if layoutMode === "compact"}
@@ -69,8 +66,8 @@
       {parseEmoji(repo.description)}
     </span>
     <span class="flex items-center gap-1 text-sm text-zinc-500 flex-shrink-0">
-      {#if isHot(repo.pushedAt)}
-        <span title="Active in last 30 days"><Icon icon="ph:fire-bold" class="w-4 h-4 text-orange-500" /></span>
+      {#if isHot}
+        <span title="Top 3"><Icon icon="ph:fire-bold" class="w-4 h-4 text-orange-500" /></span>
       {/if}
       <Icon icon="ph:star-fill" class="w-4 h-4 text-yellow-500" />
       {formatNumber(repo.stars)}
@@ -106,8 +103,8 @@
         </p>
       </div>
       <div class="flex items-center gap-4 text-sm text-zinc-500 flex-shrink-0">
-        {#if isHot(repo.pushedAt)}
-          <span title="Active in last 30 days"><Icon icon="ph:fire-bold" class="w-4 h-4 text-orange-500" /></span>
+        {#if isHot}
+          <span title="Top 3"><Icon icon="ph:fire-bold" class="w-4 h-4 text-orange-500" /></span>
         {/if}
         <span class="flex items-center gap-1">
           <Icon icon="ph:star-fill" class="w-4 h-4 text-yellow-500" />
@@ -150,8 +147,8 @@
     </p>
 
     <div class="flex items-center gap-4 text-sm text-zinc-500 mb-3">
-      {#if isHot(repo.pushedAt)}
-        <span title="Active in last 30 days"><Icon icon="ph:fire-bold" class="w-4 h-4 text-orange-500" /></span>
+      {#if isHot}
+        <span title="Top 3"><Icon icon="ph:fire-bold" class="w-4 h-4 text-orange-500" /></span>
       {/if}
       <span class="flex items-center gap-1">
         <Icon icon="ph:star-fill" class="w-4 h-4 text-yellow-500" />

--- a/src/components/svelte/RepoList.svelte
+++ b/src/components/svelte/RepoList.svelte
@@ -40,8 +40,8 @@
   </div>
 {:else}
   <div class={gridClass()}>
-    {#each displayedRepos as repo (repo.fullName)}
-      <RepoCard {repo} {layoutMode} />
+    {#each displayedRepos as repo, index (repo.fullName)}
+      <RepoCard {repo} {layoutMode} isHot={index < 3} />
     {/each}
   </div>
 

--- a/src/components/svelte/RepoList.svelte
+++ b/src/components/svelte/RepoList.svelte
@@ -5,9 +5,10 @@
   interface Props {
     repos: Repo[];
     layoutMode: LayoutMode;
+    top3FullNames: Set<string>;
   }
 
-  let { repos, layoutMode }: Props = $props();
+  let { repos, layoutMode, top3FullNames }: Props = $props();
 
   // Limit display for performance (can implement virtual scroll later)
   const DISPLAY_LIMIT = 100;
@@ -40,8 +41,8 @@
   </div>
 {:else}
   <div class={gridClass()}>
-    {#each displayedRepos as repo, index (repo.fullName)}
-      <RepoCard {repo} {layoutMode} isHot={index < 3} />
+    {#each displayedRepos as repo (repo.fullName)}
+      <RepoCard {repo} {layoutMode} isHot={top3FullNames.has(repo.fullName)} />
     {/each}
   </div>
 

--- a/src/stores/repos.ts
+++ b/src/stores/repos.ts
@@ -30,6 +30,11 @@ export const filteredRepos = derived(
   }
 );
 
+// Top 3 repos (fixed, based on original data order)
+export const top3FullNames = derived(repos, ($repos) =>
+  new Set($repos.slice(0, 3).map((r) => r.fullName))
+);
+
 export async function loadData() {
   isLoading.set(true);
   try {

--- a/src/stores/repos.ts
+++ b/src/stores/repos.ts
@@ -30,9 +30,12 @@ export const filteredRepos = derived(
   }
 );
 
-// Top 3 repos (fixed, based on original data order)
+// Number of repos to mark as "hot"
+export const HOT_REPO_COUNT = 3;
+
+// Top repos (fixed, based on original data order)
 export const top3FullNames = derived(repos, ($repos) =>
-  new Set($repos.slice(0, 3).map((r) => r.fullName))
+  new Set($repos.slice(0, HOT_REPO_COUNT).map((r) => r.fullName))
 );
 
 export async function loadData() {


### PR DESCRIPTION
## Summary
- 將「hot」標示從「30 天內有更新」改為「前三筆 repo」
- `isHot` 邏輯從 `RepoCard` 移至 `RepoList`，由父組件根據 index 決定
- Tooltip 更新為 "Top 3"

## Test plan
- [ ] 確認前三筆 repo 顯示 🔥 圖示
- [ ] 確認第四筆之後的 repo 不顯示 🔥 圖示
- [ ] 確認三種 layout mode (card, list, compact) 都正常運作
- [ ] 確認 hover tooltip 顯示 "Top 3"

🤖 Generated with [Claude Code](https://claude.com/claude-code)